### PR TITLE
replace: "execFile" -> "spawn" to solve some OS level issues

### DIFF
--- a/lib/ZabbixSender.js
+++ b/lib/ZabbixSender.js
@@ -1,5 +1,5 @@
 module.exports = ZabbixSender;
-var execFile = require('child_process').execFile;
+var spawn = require('child_process').spawn;
 
 // nullLogger: essentially a fake bunyan logger API.
 function noLog() {
@@ -60,11 +60,23 @@ ZabbixSender.prototype.send = function(data, errorCallback) {
 		debug: this.options.debug,
 	}, actionPhrase + ': %s %s', this.options.bin, cmdArgs.join(' '));
 
-	if (!this.options.debug) {
-		var stdin = execFile(this.options.bin, cmdArgs, errorCallback).stdin;
-		stdin.on ('error', function () {/* Ignore errors */});
-		stdin.end(stdIn);
-	}
+	var proc = spawn(this.options.bin, cmdArgs)
+		.on('close', errorCallback)
+		.on('error', errorCallback)
+
+	// Only show STDOUT output if in debug mode
+	if (this.options.debug)
+		proc.stdout.on('data', function(data) {
+			console.log('STDOUT>', data.toString());
+		});
+
+	// Always show errors
+	proc.stderr.on('data', function(data) {
+		console.log('STDERR>', data.toString());
+	});
+
+	proc.stdin.end(stdIn);
+
 	return this;
 };
 


### PR DESCRIPTION
There are some strange OS level issues where `execFile` always returns an error code 2 even though it runs correctly when sending Zabbix output.

This patch replaces `execFile` with the safer `spawn` option inline.